### PR TITLE
Add check for Parts being undefined

### DIFF
--- a/lib/bucket.js
+++ b/lib/bucket.js
@@ -73,7 +73,7 @@ var abortMultipartCopy = function(params, S3) {
           return Promise.reject(err);
       })
       .then((partsList) => {
-          if (partsList.Parts.length > 0) {
+          if (partsList.Parts && partsList.Parts.length > 0) {
               const err = new Error('Abort procedure passed but copy parts were not removed');
               err.details = partsList;
               return Promise.reject(err);


### PR DESCRIPTION
Fix issue: can read length of undefined error returned instead of the actual error

`TypeError: Cannot read property 'length' of undefined
   at Promise.all.catch (/app/app/components/cloud-storage/index.js:308:13)\n    at tryCatcher (/app/node_modules/bluebird/js/release/util.js:16:23)\n    at Promise._settlePromiseFromHandler (/app/node_modules/bluebird/js/release/promise.js:512:31)\n    at Promise._settlePromise (/app/node_modules/bluebird/js/release/promise.js:569:18)\n    at Promise._settlePromise0 (/app/node_modules/bluebird/js/release/promise.js:614:10)\n    at Promise._settlePromises (/app/node_modules/bluebird/js/release/promise.js:689:18)\n    at Async._drainQueue (/app/node_modules/bluebird/js/release/async.js:133:16)\n    at Async._drainQueues (/app/node_modules/bluebird/js/release/async.js:143:10)\n    at Immediate.Async.drainQueues (/app/node_modules/bluebird/js/release/async.js:17:14)\n    at runCallback (timers.js:789:20)\n    at tryOnImmediate (timers.js:751:5)\n    at processImmediate [as _immediateCallback] (timers.js:722:5)"...`